### PR TITLE
Clarify details about subctl show versions

### DIFF
--- a/submariner-operator/issue-359-subctl-info-status.md
+++ b/submariner-operator/issue-359-subctl-info-status.md
@@ -51,11 +51,8 @@ cluster2      172.17.0.5                    libreswan     remote
 subctl show versions 
 COMPONENT             VERSION
 submariner-operator   0.4.0
-submariner-engine     0.4.0
-submariner-routeagent 0.4.0
-submariner-globalnet  0.4.0
-lighthouse-agent      0.4.0
-lighthouse-coredns    0.4.0
+submariner            0.4.0
+service-discovery     0.4.0
 ```
 
 ```bash

--- a/submariner-operator/issue-359-subctl-info-status.md
+++ b/submariner-operator/issue-359-subctl-info-status.md
@@ -77,9 +77,6 @@ worker1  cluster3   172.17.0.11  libreswan        100.94.0.0/16,  10.244.0.0/16 
 
 COMPONENT             VERSION
 submariner-operator   0.4.0
-submariner-engine     0.4.0
-submariner-routeagent 0.4.0
-submariner-globalnet  0.4.0
-lighthouse-agent      0.4.0
-lighthouse-coredns    0.4.0
+submariner            0.4.0
+service-discovery     0.4.0
    ```


### PR DESCRIPTION
Currently the versions are stored in a single field on the operator,
and that's replicated for submariner-* and lighthouse-* (service-discovery).