### PR TITLE
Disable the DCO GHA

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -5,20 +5,6 @@ on:
   pull_request:
 
 jobs:
-  dco:
-    name: DCO in Commit Message(s)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get PR commits
-        id: 'get-pr-commits'
-        uses: tim-actions/get-pr-commits@master
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run DCO check
-        uses: tim-actions/dco@master
-        with:
-          commits: ${{ steps.get-pr-commits.outputs.commits }}
-
   markdown-link-check:
     name: Markdown Links (modified files)
     runs-on: ubuntu-latest


### PR DESCRIPTION
We've installed the DCO bot instead, as requested by the CNCF.

Signed-off-by: Stephen Kitt <skitt@redhat.com>