### PR TITLE
Add CII badge, remove PR-triggered badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Enhancements
 
-[![Linting](https://github.com/submariner-io/enhancements/workflows/Linting/badge.svg)](https://github.com/submariner-io/enhancements/actions?query=workflow%3ALinting)
+<!-- markdownlint-disable line-length -->
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4865/badge)](https://bestpractices.coreinfrastructure.org/projects/4865)
 [![Periodic](https://github.com/submariner-io/enhancements/workflows/Periodic/badge.svg)](https://github.com/submariner-io/enhancements/actions?query=workflow%3APeriodic)
+<!-- markdownlint-enable line-length -->
 
 This repository contains enhancement proposals for submariner-io projects.


### PR DESCRIPTION
Add Submariner's CII Best Practices badge to the README.

Remove badges for workflows triggered by PRs, as their status reflects
tests against proposed/WIP code, not merged code. This causes false red
flags, reducing the utility of the badges overall. Leave badges for
workflows run against merged code.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>