### PR TITLE
Update ibiqlik/action-yamllint GHA 1.0.0 to 3.0.4

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
       - name: Run yamllint
-        uses: ibiqlik/action-yamllint@665205c3255fcf157ef8dc9a40d527fe025a4bc8
+        uses: ibiqlik/action-yamllint@ed2b6e911569708ed121c14b87d513860a7e36a7
         with:
           file_or_dir: .
           config_file: .yamllint.yml


### PR DESCRIPTION
Depends on https://github.com/submariner-io/enhancements/pull/40.