### PR TITLE
Remove non-functional yamllint strict config

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -7,5 +7,3 @@ rules:
   # Allow standard GHA syntax for "on: *"
   truthy:
     ignore: '.github/workflows/*.yml'
-
-strict: true


### PR DESCRIPTION
Setting yamllint to exit non-zero on warnings doesn't work from the
.yamllint config file.

Set the --strict flag at CLI invocation (submariner-io/shipyard#628).

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>