### PR TITLE
Bump markdown-link-check to the current tip

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
 
       - name: Run markdown-link-check
-        uses: gaurav-nelson/github-action-markdown-link-check@58f84fd654812d0d8da4e4d4a559eda087daf8ce
+        uses: gaurav-nelson/github-action-markdown-link-check@228fbf4ffb2a86a65314866e9b2322b519fd885f
         with:
           config-file: ".markdownlinkcheck.json"
           check-modified-files-only: "yes"

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
 
       - name: Run markdown-link-check
-        uses: gaurav-nelson/github-action-markdown-link-check@58f84fd654812d0d8da4e4d4a559eda087daf8ce
+        uses: gaurav-nelson/github-action-markdown-link-check@228fbf4ffb2a86a65314866e9b2322b519fd885f
         with:
           config-file: ".markdownlinkcheck.json"
 


### PR DESCRIPTION
This hasn't been released yet but fixes the safe directories git
errors.

Signed-off-by: Stephen Kitt <skitt@redhat.com>