### PR TITLE
Run dependent issues check less frequently

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -2,22 +2,8 @@
 name: PR Dependencies
 
 on:
-  issues:
-    types:
-      - opened
-      - edited
-      - closed
-      - reopened
-      - synchronize
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - closed
-      - reopened
-      - synchronize
   schedule:
-    - cron: '0 0/6 * * *'  # every 6 hours
+    - cron: '0 1 * * *'  # Once a day at 1AM
 
 jobs:
   check:


### PR DESCRIPTION
This repo has a lot of activity relative to the number of commits.
We think this causes the dependent issue check to run on the same SHA too
many times and start failing with:

> SHA and context has reached the maximum number of statuses

This commit will also make a new SHA, which should fix the issue.

Closes: #124
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>