### PR TITLE
Run dependent issues check only on open/edit

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -2,8 +2,14 @@
 name: PR Dependencies
 
 on:
-  schedule:
-    - cron: '0 1 * * *'  # Once a day at 1AM
+  issues:
+    types:
+      - opened
+      - edited
+  pull_request_target:
+    types:
+      - opened
+      - edited
 
 jobs:
   check:


### PR DESCRIPTION
Instead of running it daily, which still seems to be too often.

This repo has a lot of activity relative to the number of commits.
We think this causes the dependent issue check to run on the same SHA too
many times and start failing with:

> SHA and context has reached the maximum number of statuses

This commit will also make a new SHA, which should fix the issue.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>