### PR TITLE
Minimize GHA permissions

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -4,6 +4,8 @@ name: Branch Checks
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   target_devel:
     name: PR targets devel

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -11,6 +11,11 @@ on:
       - opened
       - edited
 
+permissions:
+  issues: write
+  pull-requests: write
+  statuses: write
+
 jobs:
   check:
     name: Check Dependencies

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -4,6 +4,8 @@ name: Linting
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   apply-suggestions-commits:
     name: 'No "Apply suggestions from code review" Commits'

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -5,6 +5,8 @@ on:
   schedule:
     - cron: "0 0 * * 0"
 
+permissions: {}
+
 jobs:
   markdown-link-check-periodic:
     name: Markdown Links (all files)


### PR DESCRIPTION
Set the GitHub Actions token permission to null in most workflows.

This results in:

GITHUB_TOKEN Permissions
  Metadata: read

The default permissions, used without the null override, are either

GITHUB_TOKEN Permissions
  Actions: write
  Checks: write
  Contents: write
  Deployments: write
  Discussions: write
  Issues: write
  Metadata: read
  Packages: write
  Pages: write
  PullRequests: write
  RepositoryProjects: write
  SecurityEvents: write
  Statuses: write

or

GITHUB_TOKEN Permissions
  Actions: read
  Checks: read
  Contents: read
  Deployments: read
  Discussions: read
  Issues: read
  Metadata: read
  Packages: read
  Pages: read
  PullRequests: read
  RepositoryProjects: read
  SecurityEvents: read
  Statuses: read

Jobs triggered by PRs get read permissions, other jobs get write.

One job require non-null permissions to function.

The dependent issues GHA needs PR/issues write permissions to add/remove
`dependent` labels. It needs status write permission to block/unblock
PRs when dependencies are missing/met. Fails with HttpError otherwise.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>