### PR TITLE
Check GHA updates weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
-      interval: daily
+      interval: weekly


### PR DESCRIPTION
The release frequency of some GHAs means we end up with daily
dependabot PRs, which results in lots of not-particularly-useful
review work. Reducing the update cadence to weekly shouldn't expose us
to much risk and will reduce PR churn.

Signed-off-by: Stephen Kitt <skitt@redhat.com>