### PR TITLE
Bump MD link check GHA to 1.0.16

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Run markdown-link-check
-        uses: gaurav-nelson/github-action-markdown-link-check@228fbf4ffb2a86a65314866e9b2322b519fd885f
+        uses: gaurav-nelson/github-action-markdown-link-check@1b916f2cf6c36510a6059943104e3c42ce6c16bc
         with:
           config-file: ".markdownlinkcheck.json"
 


### PR DESCRIPTION
This goes from the version pinned due to #153 to the latest release.

Relates-to: #243