### PR TITLE
Fix stale bot cache issue by adding actions:write permission

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+      actions: write
     steps:
       - uses: actions/stale@997185467fa4f803885201cee163a9f38240193d
         with:


### PR DESCRIPTION
## Summary

This PR fixes a caching issue in the stale workflow where issues are being perpetually skipped with the message "skipped due being processed during the previous run".

## Problem

The stale workflow was lacking the `actions:write` permission needed to delete/update the cache between runs. Without this permission:
- The stale action creates a cache of processed issues
- It cannot delete or update this cache in subsequent runs (403 error)
- Issues get stuck in a "perpetually processing" state

This has been affecting issue #239 (and potentially others) which has not been updated since March 11, 2025, well past the 120-day stale threshold, but was never marked as stale.

## Solution

Add `actions:write` to the job permissions in `.github/workflows/stale.yml`.

## References

- Issue: https://github.com/actions/stale/issues/1131
- Related PR in actions/stale: https://github.com/actions/stale/pull/1237
- Affected issue: #239

## Testing

After this PR is merged, the next scheduled run of the stale workflow should be able to:
1. Clear the stuck cache
2. Process issue #239 and other eligible issues
3. Mark them as stale if they haven't had activity in 120+ days